### PR TITLE
Create output buffer as scratch buffer, so not prompted to save when buffer is closed

### DIFF
--- a/pipe_views.py
+++ b/pipe_views.py
@@ -38,6 +38,8 @@ class PipeViews(object):
 
         self.on_view_created(self.window, dest_view, self)
 
+        dest_view.set_scratch(True)
+
         return dest_view
 
     def prepare_copy(self, window):


### PR DESCRIPTION
Tiny tweak to create buffer as scratch buffer, so there isn't a prompt to save it whenever you try to close it. (Liked the plugin, but this behaviour was annoying me). Tested in ST3, should work in ST2.