### PR TITLE
Add build output syntax and settings

### DIFF
--- a/Build Output.sublime-settings
+++ b/Build Output.sublime-settings
@@ -1,0 +1,6 @@
+{
+    "rulers": [],
+    "line_numbers": false,
+    "gutter": false,
+    "show_minimap": false
+}

--- a/Build Output.tmLanguage
+++ b/Build Output.tmLanguage
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Build Output</string>
+	<key>scopeName</key>
+	<string>text.buildoutput</string>
+</dict>
+</plist>

--- a/pipe_views.py
+++ b/pipe_views.py
@@ -39,6 +39,7 @@ class PipeViews(object):
 
         dest_view.set_name(self.dest_view_name)
         dest_view.set_scratch(settings.available.SilenceModifiedWarning.get_value())
+        dest_view.set_syntax_file('Packages/sublime-text-2-buildview/Build Output.tmLanguage')
 
         self.dest_view = dest_view
 


### PR DESCRIPTION
Hey!
This was a little something I put together in my own installation to just clean up the build output tab - disabling line numbers, the gutter, rulers, and so on (without messing with normal plain text editing). Not sure if this is something you'd necessarily want to merge, but figured I might as well share in case somebody was interested. :smile: